### PR TITLE
add quickstart to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
 # cleverelements
+
+## Quick Start
+
+### Set up client
+```
+require 'cleverlements'
+
+client = CleverElements::Client.new('API_ID', 'API_KEY', 'live') # Use test if you do not want to write to the API
+```
+
+### Get all mailing lists
+```
+client.lists.all
+```
+
+### Get specific list
+```
+client.lists.find(LIST_ID)
+```
+
+### Get all subscribers for a specific list
+```
+client.lists.get_subscribers(LIST_ID)
+```
+
+### Add new subscriber(s) to list
+```
+subscribers = [
+  {
+    list_id: LIST_ID,
+    email: 'subscriber@domain.com'
+    custom_fields: [{field_id: 818718, field_value: 'Sir'}]
+  },
+  {
+    list_id: LIST_ID,
+    email: 'subscriber2@domain.com'
+    custom_fields: [{field_id: 818718, field_value: 'Madam'}]
+  }
+]
+
+client.subscribers.create(subscribers)
+```
+
+### Find subscriber by email
+```
+client.subscribers.find_by_email('subscriber@domain.com')
+```


### PR DESCRIPTION
I've been banging my head against the wall for about two hours trying to figure out why my requests are not getting saved to my account. I found out that I was missing the `live` attribute in the initalizer after reading through the source code. 

I've added a Quick Start section to the `README.md` in the hope that it will help other (stupid) people like me to get started more quickly.

Cheers